### PR TITLE
Improve SNESIM -mg parsing and MATLAB examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ example/.venv/
 *.config
 *.Rhistory
 *.log
+*.mlx.autosave
 
 *.depend
 .depend

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-10
 
+- Expanded the MATLAB SNESIM example to use the public Strebelle training image more robustly, with a fallback download path for MATLAB releases that cannot `imread()` HTTP URLs directly, plus elapsed-time reporting.
+- Corrected the MATLAB SNESIM example to follow the categorical MATLAB test pattern more closely by casting the Strebelle TIFF and destination grid to `single`, using a normal `-j 0.5` thread setting, and rendering categorical outputs with `imagesc`.
+- Updated the SNESIM algorithm page and top-level README to point to the MATLAB/Python Strebelle examples explicitly.
 - Added SNESIM support for `-wPO` path-optimization scheduling by threading the flag through `src/snesim.cpp` into the shared vector `simulation()` loop.
 - Fixed the SNESIM `simulation()` call to match the current callback-aware signature, preserving explicit `posteriorPath` tracking and progress callbacks when path optimization is disabled or enabled.
 - Documented the SNESIM `-wPO` option in the algorithm docs and top-level README.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 Currently the **G2S** interface is available for *MATLAB* and *Python*. **G2S** is provided with **QS** (QuickSampling), **AS** (Anchor Sampling), and **NDS** (Narrow Distribution Selection).
 The repository also includes a dedicated **SNESIM** executable for categorical multigrid simulation, including the `-wPO` path-optimization scheduling option shared with vector-path simulation.
+Concrete interface demos live under `example/matlab/` and `example/python/`, including `snesim_example.m` / `snesim_example.py` using the public Strebelle training image. The MATLAB SNESIM example follows the categorical MATLAB test pattern by casting the TIFF to `single` before calling `g2s`.
 
 **G2S** is currently only available for *UNIX*-based systems, *Linux* and *macOS*. A solution for *Windows 10+* is provided using *WSL* (Windows Subsystem for Linux). However, for previous *Windows* versions, the only solution currently available is to install a *Linux* system manually inside a virtual machine. 
 

--- a/docs/algorithms/SNESIM.md
+++ b/docs/algorithms/SNESIM.md
@@ -87,25 +87,40 @@ plt.show()
 ```matlab
 %This code requires the G2S server to be running
 % load example training image ('strebelle')
-ti=imread('https://raw.githubusercontent.com/GAIA-UNIL/TrainingImagesTIFF/master/strebelle.tiff');
+url = 'https://raw.githubusercontent.com/GAIA-UNIL/TrainingImagesTIFF/master/strebelle.tiff';
+try
+    ti = imread(url);
+catch
+    % Older MATLAB releases may not support direct HTTP reads with imread.
+    localTi = websave(fullfile(tempdir, 'strebelle.tiff'), url);
+    ti = imread(localTi);
+end
+ti = single(ti);
 
 % SNESIM call using G2S
-simulation=g2s('-a','snesim',...
-               '-ti',ti,...
-               '-di',nan(1000,1000),...
-               '-dt',[1],...
-               '-j',0.5,...
-               '-mg',4,...
-               '-tpl',3);
+% 5 grid levels total: 4 -> 3 -> 2 -> 1 -> 0 (because -mg is the max level)
+[simulation, elapsed] = g2s('-a', 'snesim', ...
+                            '-ti', ti, ...
+                            '-di', single(nan(200, 200)), ...
+                            '-dt', [1], ...
+                            '-j', 0.5, ...
+                            '-mg', 4, ...
+                            '-tpl', 3);
+
+fprintf('SNESIM duration: %.3f s\n', elapsed);
 
 % Display results
+figure;
 sgtitle('SNESIM unconditional simulation');
-subplot(1,2,1);
-imshow(ti,[]);
-title('Training image');
-subplot(1,2,2);
-imshow(simulation,[]);
+subplot(1, 2, 1);
+imagesc(ti);
+title('Training image (Strebelle)');
+axis image off;
+colormap(parula);
+subplot(1, 2, 2);
+imagesc(simulation);
 title('Simulation');
+axis image off;
 ```
 
 </div>

--- a/example/matlab/snesim_example.m
+++ b/example/matlab/snesim_example.m
@@ -1,20 +1,36 @@
+% This code requires the G2S server to be running.
 % load example training image ('strebelle')
-ti=imread('https://raw.githubusercontent.com/GAIA-UNIL/TrainingImagesTIFF/master/strebelle.tiff');
+url = 'https://raw.githubusercontent.com/GAIA-UNIL/TrainingImagesTIFF/master/strebelle.tiff';
+try
+    ti = imread(url);
+catch
+    % Older MATLAB releases may not support direct HTTP reads with imread.
+    localTi = websave(fullfile(tempdir, 'strebelle.tiff'), url);
+    ti = imread(localTi);
+end
+ti = single(ti);
 
 % SNESIM call using G2S
-simulation=g2s('-a','snesim',...
-               '-ti',ti,...
-               '-di',nan(1000,1000),...
-               '-dt',[1],...
-               '-j',0.5,...
-               '-mg',4,...
-               '-tpl',3);
+% 5 grid levels total: 4 -> 3 -> 2 -> 1 -> 0 (because -mg is the max level)
+[simulation, elapsed] = g2s('-a', 'snesim', ...
+                            '-ti', single(ti), ...
+                            '-di', single(nan(1000, 1000)), ...
+                            '-dt', [1], ...
+                            '-j', 1.001, ...
+                            '-mg', 4, ...
+                            '-tpl', 3);
+
+fprintf('SNESIM duration: %.3f s\n', elapsed);
 
 % Display results
+figure;
 sgtitle('SNESIM unconditional simulation');
-subplot(1,2,1);
-imshow(ti,[]);
-title('Training image');
-subplot(1,2,2);
-imshow(simulation,[]);
+subplot(1, 2, 1);
+imagesc(ti);
+title('Training image (Strebelle)');
+axis image off;
+subplot(1, 2, 2);
+imagesc(simulation);
 title('Simulation');
+axis image off;
+colormap(parula);

--- a/src/snesim.cpp
+++ b/src/snesim.cpp
@@ -320,19 +320,39 @@ bool parseCliOptions(int argc, const char* argv[], CliOptions& outOptions) {
 	if (args.count("-mg") >= 1) {
 		unsigned parsedMaxLevel = outOptions.simulationConfig.maxGridLevel;
 		bool hasValidValue = false;
-		for (std::multimap<std::string, std::string>::iterator it = args.lower_bound("-mg"); it != args.upper_bound("-mg"); ++it) {
-			unsigned level;
-			if (!parseUnsignedFromString(it->second, level)) {
+
+		for (auto it = args.lower_bound("-mg"); it != args.upper_bound("-mg"); ++it) {
+			double val;
+
+			try {
+				size_t idx;
+				val = std::stod(it->second, &idx);
+
+				// ensure full string was parsed (no "12abc")
+				if (idx != it->second.size()) {
+					throw std::invalid_argument("partial parse");
+				}
+			} catch (...) {
 				fprintf(outOptions.reportFile, "[SNESIM] invalid -mg value ignored: %s\n", it->second.c_str());
 				continue;
 			}
+
+			// avoid negative → unsigned wraparound
+			if (val < 0.0) {
+				fprintf(outOptions.reportFile, "[SNESIM] negative -mg value ignored: %s\n", it->second.c_str());
+				continue;
+			}
+
+			unsigned level = static_cast<unsigned>(std::round(val));
 			parsedMaxLevel = std::max(parsedMaxLevel, level);
 			hasValidValue = true;
 		}
+
 		if (hasValidValue) {
 			outOptions.simulationConfig.maxGridLevel = parsedMaxLevel;
 		}
 	}
+
 	args.erase("-mg");
 
 	if (args.count("--mg-level") >= 1) {


### PR DESCRIPTION
Add robustness and usability improvements across the SNESIM examples and CLI parsing. Updates include:

- MATLAB example and docs: add HTTP-read fallback (websave) for older MATLAB releases, cast training image and destination grid to single, report elapsed time from g2s, render categorical outputs with imagesc, and minor display/layout tweaks. README and algorithm docs updated to point to the examples.
- CLI parsing: make -mg value parsing more robust in src/snesim.cpp by using std::stod, accepting floating inputs (rounded to nearest unsigned), rejecting negative/partially-parsed values, and preventing unsigned wraparound.
- Misc: ignore MATLAB autosave files (*.mlx.autosave) in .gitignore, and update CHANGES.md with the above improvements.

Files changed: .gitignore, CHANGES.md, README.md, docs/algorithms/SNESIM.md, example/matlab/snesim_example.m, src/snesim.cpp.