### PR TITLE
Remove SNESIM path-optimization support (-wPO)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ example/.venv/
 *.Rhistory
 *.log
 *.mlx.autosave
+# Temporary SNESIM investigation artifacts also stay local.
 
 *.depend
 .depend

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,15 @@
 # Changes
 
+## 2026-05-12
+
+- Removed the short-lived SNESIM path-optimization CLI support, logging, and documentation. SNESIM now always uses the default per-level execution order built by its multigrid planner.
+
 ## 2026-05-10
 
 - Expanded the MATLAB SNESIM example to use the public Strebelle training image more robustly, with a fallback download path for MATLAB releases that cannot `imread()` HTTP URLs directly, plus elapsed-time reporting.
 - Corrected the MATLAB SNESIM example to follow the categorical MATLAB test pattern more closely by casting the Strebelle TIFF and destination grid to `single`, using a normal `-j 0.5` thread setting, and rendering categorical outputs with `imagesc`.
 - Updated the SNESIM algorithm page and top-level README to point to the MATLAB/Python Strebelle examples explicitly.
-- Added SNESIM support for `-wPO` path-optimization scheduling by threading the flag through `src/snesim.cpp` into the shared vector `simulation()` loop.
 - Fixed the SNESIM `simulation()` call to match the current callback-aware signature, preserving explicit `posteriorPath` tracking and progress callbacks when path optimization is disabled or enabled.
-- Documented the SNESIM `-wPO` option in the algorithm docs and top-level README.
 
 ## 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - the second part is composed of different interfaces that communicate with the server through ZeroMQ. Interfaces can be added for each software. Similarly, G2S can be extended for any other geostatistical simulation algorithm.
 
 Currently the **G2S** interface is available for *MATLAB* and *Python*. **G2S** is provided with **QS** (QuickSampling), **AS** (Anchor Sampling), and **NDS** (Narrow Distribution Selection).
-The repository also includes a dedicated **SNESIM** executable for categorical multigrid simulation, including the `-wPO` path-optimization scheduling option shared with vector-path simulation.
+The repository also includes a dedicated **SNESIM** executable for categorical multigrid simulation.
 Concrete interface demos live under `example/matlab/` and `example/python/`, including `snesim_example.m` / `snesim_example.py` using the public Strebelle training image. The MATLAB SNESIM example follows the categorical MATLAB test pattern by casting the TIFF to `single` before calling `g2s`.
 
 **G2S** is currently only available for *UNIX*-based systems, *Linux* and *macOS*. A solution for *Windows 10+* is provided using *WSL* (Windows Subsystem for Linux). However, for previous *Windows* versions, the only solution currently available is to install a *Linux* system manually inside a virtual machine. 

--- a/docs/algorithms/SNESIM.md
+++ b/docs/algorithms/SNESIM.md
@@ -23,7 +23,6 @@ Usage: `[sim,time,...] = g2s(flag1,value1, flag2,value2, ...)`
 | `-j` | Number of worker threads. Decimal values in `]0,1[` represent a fraction of the available logical cores. |  |
 | `-mg` | Maximum multigrid level. The execution proceeds from this level down to `0`. |  |
 | `-tpl` | Template radius. A value of `3` means offsets in `[-3,+3]`. Provide one value per dimension if needed. |  |
-| `-wPO` | Enable path optimization within each multigrid level. This reorders execution to reduce dependency stalls while preserving the original path-order conditioning rules. |  |
 | `--tree-strategy` | Tree-selection strategy. Supported values are `first`, `ii`, and `merged`. Default: `merged`. |  |
 | `-tree-root` | Root directory used for the SNESIM tree cache. |  |
 | `-force-tree` | Force a rebuild of the tree cache instead of reusing cached trees. |  |
@@ -129,5 +128,4 @@ axis image off;
 
 - SNESIM is intended for categorical variables.
 - The multigrid controls are specific to this algorithm.
-- `-wPO` only changes the execution schedule inside a level; it does not change the multigrid path definition or neighbor eligibility rules.
 - Tree caching is managed internally by the executable and can be controlled with `-tree-root` and `-force-tree`.

--- a/src/snesim.cpp
+++ b/src/snesim.cpp
@@ -45,7 +45,6 @@ struct SimulationRunConfig {
 	unsigned nbThreads = 1;
 	unsigned seed = 0;
 	unsigned maxGridLevel = 0;
-	bool withPathOptim = false;
 	std::vector<int> templateRadius;
 };
 
@@ -126,7 +125,6 @@ void printHelp() {
 	printf("  -mg <level>                   Max multi-grid level (levels run from <level> down to 0)\n");
 	printf("  -tpl <radius> [repeat]        Template radius (3 means offsets in [-3,+3])\n");
 	printf("  --template-radius <radius>    Same as -tpl\n");
-	printf("  -wPO                          Reorder each level path to reduce dependency stalls\n");
 	printf("  -tree-root <path>             Tree cache root (optional)\n");
 	printf("  -force-tree                   Force tree rebuild and overwrite cache\n");
 	printf("  -s <seed>                     Random seed (optional)\n");
@@ -265,11 +263,6 @@ bool parseCliOptions(int argc, const char* argv[], CliOptions& outOptions) {
 		}
 	}
 	args.erase("--jobs");
-
-	if (args.count("-wPO") == 1) {
-		outOptions.simulationConfig.withPathOptim = true;
-	}
-	args.erase("-wPO");
 
 	if (args.count("-v") == 1 || args.count("--verbose") == 1) {
 		outOptions.verbose = true;
@@ -1190,10 +1183,9 @@ int main(int argc, char const* argv[]) {
 			static_cast<unsigned>(levelPlan.pathPositionArray.size()));
 
 			fprintf(reportFile,
-				"[SNESIM] level %u running default simulation() with %lu path nodes (wPO=%s)\n",
+				"[SNESIM] level %u running default simulation() with %lu path nodes\n",
 				levelPlan.level,
-				static_cast<unsigned long>(levelPlan.simulationPath.size()),
-				(options.simulationConfig.withPathOptim ? "on" : "off"));
+				static_cast<unsigned long>(levelPlan.simulationPath.size()));
 
 		simulation(reportFile,
 			destinationImage,
@@ -1216,7 +1208,7 @@ int main(int argc, char const* argv[]) {
 				false,
 				false,
 				false,
-				options.simulationConfig.withPathOptim,
+				false,
 				posteriorPath.data(),
 				(overallSimulationPointCount > 0ULL ? snesimOverallProgressCallback : nullptr),
 				(overallSimulationPointCount > 0ULL ? static_cast<void*>(&overallProgressContext) : nullptr));


### PR DESCRIPTION
Drop the short-lived SNESIM -wPO path-optimization feature and related plumbing. Remove the CLI flag, help text, parsing, config field (withPathOptim), runtime logging, and the code path that forwarded the option into simulation(); simulation() is now always invoked with path-optimization disabled. Update docs and README to remove references to -wPO, add a CHANGES.md entry explaining the removal, and add a .gitignore note for temporary investigation artifacts. Files changed: src/snesim.cpp, docs/algorithms/SNESIM.md, README.md, CHANGES.md, .gitignore.